### PR TITLE
remove host option in config file, taken care in cli

### DIFF
--- a/configs/config-depl.json
+++ b/configs/config-depl.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "auth.iudx.io",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -4,7 +4,6 @@
     "zookeeper"
   ],
   "clusterId": "iudx-aaa-cluster",
-  "host": "server",
   "databaseSchema":"test",
   "modules": [
     {

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -201,6 +201,13 @@ public class Deployer {
 
   }
 
+  /**
+   * Graceful shutdown of Vertx application in a sequential manner - 1) undeploy verticle including
+   * unregistering of services through the stop method of verticle 2) unregister the vertx from
+   * cluster 3) shutdown of vertx 4) shutdown of log4g2. The function is triggered by shutdown hook
+   * on a normal shutdown of application.
+   */
+
   public static void gracefulShutdown() {
     Set<String> deployIDSet = vertx.deploymentIDs();
     Logger LOGGER = LogManager.getLogger(Deployer.class);

--- a/src/main/java/iudx/aaa/server/deploy/Deployer.java
+++ b/src/main/java/iudx/aaa/server/deploy/Deployer.java
@@ -63,7 +63,6 @@ public class Deployer {
       return;
     }
     JsonObject config = configs.getJsonArray("modules").getJsonObject(i);
-    config.put("host", configs.getString("host"));
     String moduleName = config.getString("id");
     int numInstances = config.getInteger("verticleInstances");
     vertx.deployVerticle(moduleName,
@@ -101,7 +100,6 @@ public class Deployer {
       return;
     }
 
-    config.put("host", configs.getString("host"));
     int numInstances = config.getInteger("verticleInstances");
     vertx.deployVerticle(moduleName,
         new DeploymentOptions().setInstances(numInstances).setConfig(config), ar -> {


### PR DESCRIPTION
The host option is taken through cli, because the container hostname is dynamic and to pass that info, the best place is through cli!

adding some docs for graceful shutdown, not sure of format. review this is how it should be!